### PR TITLE
升级qq轻聊版到最新版, 同时修复QQ轻聊版.desktop Exec指令不对的问题

### DIFF
--- a/verb/qqlight.verb
+++ b/verb/qqlight.verb
@@ -3,7 +3,7 @@ w_metadata qqlight apps \
  publisher="Tencent" \
  year="2015" \
  media="download" \
- file1="QQ7.5Light.exe" \
+ file1="QQ7.7Light.exe" \
  file2="QQLight.tar.gz"\
  installed_exe1="$W_PROGRAMS_X86_WIN/Tencent/QQ/Bin/QQScLauncher.exe" \
  homepage="http://www.qq.com" \
@@ -11,7 +11,7 @@ w_metadata qqlight apps \
 
 load_qqlight()
 {
-    w_download http://dldir1.qq.com/qqfile/qq/QQ7.5Light/15462/QQ7.5Light.exe e75a0a7ee9ae00283ca5cf18221409c3acf60695
+    w_download http://dldir1.qq.com/qqfile/qq/QQ7.7Light/14298/QQ7.7Light.exe 735d0006dc47513bd62c07d4d28d487880972fff
     w_download http://hillwoodhome.net/wine/QQLight.tar.gz db04deb656c0cce7b223cc3358a8af98b0deed52
 
     if w_workaround_wine_bug 29636 "Installing native riched20 to work around crash bug"
@@ -40,7 +40,7 @@ load_qqlight()
         w_try mv QQLight/QQ轻聊版.desktop $HOME/.local/share/applications/wine/Programs/腾讯软件/QQ轻聊版
         w_try mv QQLight/48x48/QQLight.png $HOME/.local/share/icons/hicolor/48x48/apps
         w_try mv QQLight/256x256/QQLight.png $HOME/.local/share/icons/hicolor/256x256/apps
-        w_try echo Exec=env WINEPREFIX=$WINEPREFIX $WINE \"$W_PROGRAMS_X86_WIN\\Tencent\\QQLite\\bin\\QQScLauncher.exe\" >> $HOME/.local/share/applications/wine/Programs/腾讯软件/QQ轻聊版/QQ轻聊版.desktop
+        echo Exec=env WINEPREFIX=$WINEPREFIX $WINE \"$W_PROGRAMS_X86_WIN\\\\Tencent\\\\QQLite\\\\bin\\\\QQScLauncher.exe\" >> $HOME/.local/share/applications/wine/Programs/腾讯软件/QQ轻聊版/QQ轻聊版.desktop
     fi
 
     if w_workaround_wine_bug 39384 "Set permission as 000 for QQFrmMgr.sys to work around can't be started bug"


### PR DESCRIPTION
修复详情见commit. 测试使用的OS: Linuxmint 17.2, wine version 1.7.50 from ubuntu ppa.

但是还有个问题就是, 一旦开启过一个qq实例，第二个实例就怎么也无法输入密码，必须手工

    WINEPREFIX=~/.local/share/wineprefix/qqlight wineboot -k

之后才可以正常使用qq。 自动登录也没有效果，望解决。