### PR TITLE
修复路径错误

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ set(WINETRICKS_PKGDATADIR ${WINETRICKS_PREFIX}/share/winetricks-zh)
 set(WINETRICKS_VERSION 20171018.1)
 
 install(PROGRAMS  winetricks-zh                 DESTINATION ${WINETRICKS_PREFIX}/bin)
-install(FILES     icons/winetricks-zh.svg       DESTINATION ${WINETRICKS_PREFIX}/share/icons/hicolor/scalable/apps)
+install(FILES     icon/winetricks-zh.svg       DESTINATION ${WINETRICKS_PREFIX}/share/icons/hicolor/scalable/apps)
 install(FILES     winetricks-zh.desktop         DESTINATION ${WINETRICKS_PREFIX}/share/applications)
 install(DIRECTORY verb/                         DESTINATION ${WINETRICKS_PKGDATADIR})


### PR DESCRIPTION
```
Install the project...
-- Install configuration: ""
-- Up-to-date: /usr/bin/winetricks-zh
CMake Error at cmake_install.cmake:61 (file):
  file INSTALL cannot find
  "/home/bird/git/winetricks-zh/icons/winetricks-zh.svg".
```